### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - setuptools
     - networkx>=3.10
     - tqdm
-    - pyautogen
+    - ag2
   build:
     - python
     - setuptools
@@ -24,7 +24,7 @@ requirements:
     - python>=3.10
     - networkx>=3.10
     - tqdm
-    - pyautogen
+    - ag2
 
 about:
   home: "https://github.com/giuliorossetti/LLM_Network"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ MOCK_MODULES = [
     "matplotlib",
     "numpy",
     "scipy",
-    "pyautogen",
+    "ag2",
     "autogen",
     "networkx",
     "tqdm",

--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ name: package_name
 dependencies:
 - python>=3.10
 - networkx>=3.0
-- pyautogen
+- ag2
 - tqdm


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
